### PR TITLE
Do not set NFS_DRIVER_IMAGE variable

### DIFF
--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -20,8 +20,6 @@ spec:
         env:
         - name: DRIVER_IMAGE
           value: quay.io/openshift/origin-openstack-cinder-csi-driver:latest
-        - name: NFS_DRIVER_IMAGE
-          value: quay.io/openshift/origin-csi-driver-nfs:latest
         - name: PROVISIONER_IMAGE
           value: quay.io/openshift/origin-csi-external-provisioner:latest
         - name: ATTACHER_IMAGE


### PR DESCRIPTION
We don't use NFS CSI driver for Cinder, so we don't have to set this variable.