### PR TITLE
Enable topology support

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -58,6 +58,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
+            - "--feature-gates=Topology=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -159,6 +159,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
+            - "--feature-gates=Topology=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
According to the documentation Cinder CSI driver supports Topology feature[1].

This commit enables the feature for the external provisioner.

[1] https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/features.md#topology