### PR TITLE
Bug 1902546: Allow cinder-csi-driver-node pods to run everywhere

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -18,8 +18,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
+        - operator: Exists
       containers:
         - name: csi-driver
           securityContext:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -334,8 +334,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
+        - operator: Exists
       containers:
         - name: csi-driver
           securityContext:


### PR DESCRIPTION
The `cinder-csi-driver-node` pods are supposed to run on every nodes.

This allows master to use PVCs too.