### PR TITLE
Replace cacert path before starting the driver

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -26,6 +26,13 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: "NoSchedule"
+      initContainers:
+        - name: init-cindercsi
+          image: ${DRIVER_IMAGE}
+          command: ['sh', '-c', "sed -i 's/cacert:.*/cacert: \/etc\/kubernetes\/static-pod-resources\/configmaps\/cloud-config\/ca-bundle.pem/g' /etc/kubernetes/secret/clouds.yaml"]
+          volumeMounts:
+          - name: secret-cinderplugin
+            mountPath: /etc/kubernetes/secret
       containers:
         - name: csi-driver
           image: ${DRIVER_IMAGE}

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -127,6 +127,13 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: "NoSchedule"
+      initContainers:
+        - name: init-cindercsi
+          image: ${DRIVER_IMAGE}
+          command: ['sh', '-c', "sed -i 's/cacert:.*/cacert: \/etc\/kubernetes\/static-pod-resources\/configmaps\/cloud-config\/ca-bundle.pem/g' /etc/kubernetes/secret/clouds.yaml"]
+          volumeMounts:
+          - name: secret-cinderplugin
+            mountPath: /etc/kubernetes/secret
       containers:
         - name: csi-driver
           image: ${DRIVER_IMAGE}


### PR DESCRIPTION
In OCP versions <4.6 we included the original host cacert path in `clouds.yaml`. It is wrong because internally we always use
"/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem". 
The issue was fixed in the installer [1] in 4.6 but we still have to replace incorrect values in the generated clouds.yaml for the
previous versions.

[1] https://github.com/openshift/installer/pull/4227