### PR TITLE
Bug 1905849: create default VolumeSnapshotClass

### DIFF
--- a/assets/volumesnapshotclass.yaml
+++ b/assets/volumesnapshotclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: standard-csi
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: cinder.csi.openstack.org
+deletionPolicy: Delete
+parameters:
+  force-create: "false"

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -24,6 +24,7 @@
 // assets/service.yaml
 // assets/servicemonitor.yaml
 // assets/storageclass.yaml
+// assets/volumesnapshotclass.yaml
 package generated
 
 import (
@@ -1241,6 +1242,33 @@ func storageclassYaml() (*asset, error) {
 	return a, nil
 }
 
+var _volumesnapshotclassYaml = []byte(`apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: standard-csi
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: cinder.csi.openstack.org
+deletionPolicy: Delete
+parameters:
+  force-create: "false"
+`)
+
+func volumesnapshotclassYamlBytes() ([]byte, error) {
+	return _volumesnapshotclassYaml, nil
+}
+
+func volumesnapshotclassYaml() (*asset, error) {
+	bytes, err := volumesnapshotclassYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "volumesnapshotclass.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -1317,6 +1345,7 @@ var _bindata = map[string]func() (*asset, error){
 	"service.yaml":                            serviceYaml,
 	"servicemonitor.yaml":                     servicemonitorYaml,
 	"storageclass.yaml":                       storageclassYaml,
+	"volumesnapshotclass.yaml":                volumesnapshotclassYaml,
 }
 
 // AssetDir returns the file names below a certain
@@ -1383,9 +1412,10 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"snapshotter_binding.yaml":           {rbacSnapshotter_bindingYaml, map[string]*bintree{}},
 		"snapshotter_role.yaml":              {rbacSnapshotter_roleYaml, map[string]*bintree{}},
 	}},
-	"service.yaml":        {serviceYaml, map[string]*bintree{}},
-	"servicemonitor.yaml": {servicemonitorYaml, map[string]*bintree{}},
-	"storageclass.yaml":   {storageclassYaml, map[string]*bintree{}},
+	"service.yaml":             {serviceYaml, map[string]*bintree{}},
+	"servicemonitor.yaml":      {servicemonitorYaml, map[string]*bintree{}},
+	"storageclass.yaml":        {storageclassYaml, map[string]*bintree{}},
+	"volumesnapshotclass.yaml": {volumesnapshotclassYaml, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -68,6 +68,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		[]string{
 			"configmap.yaml",
 			"storageclass.yaml",
+			"volumesnapshotclass.yaml",
 			"csidriver.yaml",
 			"controller_sa.yaml",
 			"node_sa.yaml",


### PR DESCRIPTION
Now it's not possible to make volume snapshots right after installation, because there are no VolumeSnapshotClasses in the system.

This commit allows the operator to generate a default VolumeSnapshotClass along with the driver provisioning.