### PR TITLE
Bug 1954003: Fix snapshotter metrics endpoint

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -183,7 +183,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--http-endpoint=localhost:8205"
+            - "--metrics-address=localhost:8205"
             - "--v=${LOG_LEVEL}"
           env:
             - name: ADDRESS

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -290,7 +290,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--http-endpoint=localhost:8205"
+            - "--metrics-address=localhost:8205"
             - "--v=${LOG_LEVEL}"
           env:
             - name: ADDRESS


### PR DESCRIPTION
The snapshotter supports only `--metrics-address` to set up http endpoint for metrics. `--http-address` is silently ignored.

@openshift/storage 