### PR TITLE
Bug 1989215: [openstack-cinder-csi-driver-operator] csi-liveness-probe is not deployed

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,6 @@ approvers:
 - jsafrane
 - tsmetana
 - gnufied
-- huffmanca
+- dobsonj
 - mandre
 component: "Storage"

--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -59,6 +59,19 @@ spec:
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
               value: /etc/kubernetes/config/cloud.conf
+          ports:
+            - name: healthz
+              # Due to hostNetwork, this port is open on a node!
+              containerPort: 10301
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 5
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -232,6 +245,20 @@ spec:
           volumeMounts:
           - mountPath: /etc/tls/private
             name: metrics-serving-cert
+        - name: csi-liveness-probe
+          image: ${LIVENESS_PROBE_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=10301
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
       volumes:
         - name: socket-dir
           emptyDir:

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -66,6 +66,19 @@ spec:
               readOnly: true
             - name: cacert
               mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+          ports:
+            - name: healthz
+              # Due to hostNetwork, this port is open on all nodes!
+              containerPort: 10300
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 5
           resources:
             requests:
               memory: 50Mi
@@ -95,6 +108,20 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
+        - name: csi-liveness-probe
+          image: ${LIVENESS_PROBE_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=10300
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
           resources:
             requests:
               memory: 50Mi


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1989215
cc @openshift/storage 