### PR TITLE
Bug 2027685: relax health probes against Cinder API

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -69,8 +69,8 @@ spec:
               path: /healthz
               port: healthz
             initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 10
+            timeoutSeconds: 10
+            periodSeconds: 30
             failureThreshold: 5
           volumeMounts:
             - name: socket-dir
@@ -262,7 +262,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
-            - --probe-timeout=3s
+            - --probe-timeout=10s
             - --health-port=10301
             - --v=${LOG_LEVEL}
           volumeMounts:

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -76,8 +76,8 @@ spec:
               path: /healthz
               port: healthz
             initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 10
+            timeoutSeconds: 10
+            periodSeconds: 30
             failureThreshold: 5
           resources:
             requests:
@@ -117,7 +117,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
-            - --probe-timeout=3s
+            - --probe-timeout=10s
             - --health-port=10300
             - --v=${LOG_LEVEL}
           volumeMounts:


### PR DESCRIPTION
We have noticed that the current timeout values are not working against
certain clouds, like PSI, but potentially other customer clouds which
might be slower for some reasons (remote clouds, or large
infrastructures, etc).

This patch will relax the numbers by waiting 10s instead of 3s for the
check to finish, and instead of running it ever 10s, we'll run it every
30s (twice a minute) which should be enough for our needs.
