### PR TITLE
Bug 2061732: Fail gracefully on failure to populate cloud info

### DIFF
--- a/pkg/operator/cloudinfo.go
+++ b/pkg/operator/cloudinfo.go
@@ -7,8 +7,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/availabilityzones"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	azutils "github.com/gophercloud/utils/openstack/compute/v2/availabilityzones"
-
-	"k8s.io/klog/v2"
 )
 
 // CloudInfo caches data fetched from the user's openstack cloud
@@ -53,8 +51,7 @@ func getCloudInfo() (*CloudInfo, error) {
 
 	err = ci.collectInfo()
 	if err != nil {
-		klog.Warningf("Failed to generate OpenStack cloud info: %v", err)
-		return nil, nil
+		return nil, fmt.Errorf("failed to generate OpenStack cloud info: %w", err)
 	}
 
 	return ci, nil


### PR DESCRIPTION
Not doing so would later lead to segfault, when we assume either
ci.ComputeZones or ci.VolumeZones have at least one element.