### PR TITLE
Set fsGroupPolicy in CSIDriver

### DIFF
--- a/assets/csidriver.yaml
+++ b/assets/csidriver.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: true
+  fsGroupPolicy: File
+  requiresRepublish: false
+  storageCapacity: false
   volumeLifecycleModes:
   - Persistent
   - Ephemeral

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/openshift/api v0.0.0-20220118164408-e83d48817f01
 	github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
-	github.com/openshift/library-go v0.0.0-20220117173518-ca57b619b5d6
+	github.com/openshift/library-go v0.0.0-20220308152156-227dd2b19774
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/cobra v1.2.1
 	k8s.io/api v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -521,8 +521,8 @@ github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3 h1:65
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6bGD0X4mhkTNupjVnByMYYuW4XbnCPavQU=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3/go.mod h1:cwhyki5lqBmrT0m8Im+9I7PGFaraOzcYPtEz93RcsGY=
-github.com/openshift/library-go v0.0.0-20220117173518-ca57b619b5d6 h1:HS6brMoum1oJyFriix+Ae3J2FfvK9u9TBqUu+JnG/pc=
-github.com/openshift/library-go v0.0.0-20220117173518-ca57b619b5d6/go.mod h1:4UQ9snU1vg53fyTpHQw3vLPiAxI8ub5xrc+y8KPQQFs=
+github.com/openshift/library-go v0.0.0-20220308152156-227dd2b19774 h1:GeCzQyJQ8biS12aYEbJrirh1DGmub2ZxcrNorMgR4XQ=
+github.com/openshift/library-go v0.0.0-20220308152156-227dd2b19774/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
@@ -206,13 +206,13 @@ func ApplyDirectly(ctx context.Context, clients *ClientHolder, recorder events.R
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyValidatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyValidatingWebhookConfigurationImproved(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t, cache)
 			}
 		case *admissionregistrationv1.MutatingWebhookConfiguration:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyMutatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyMutatingWebhookConfigurationImproved(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t, cache)
 			}
 		case *storagev1.CSIDriver:
 			if clients.kubeClient == nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/storage.go
@@ -2,14 +2,13 @@ package resourceapply
 
 import (
 	"context"
+	"fmt"
 
 	storagev1 "k8s.io/api/storage/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	storageclientv1 "k8s.io/client-go/kubernetes/typed/storage/v1"
-	storageclientv1beta1 "k8s.io/client-go/kubernetes/typed/storage/v1beta1"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -58,39 +57,18 @@ func ApplyStorageClass(ctx context.Context, client storageclientv1.StorageClasse
 	return actual, true, err
 }
 
-// ApplyCSIDriverV1Beta1 merges objectmeta, does not worry about anything else
-func ApplyCSIDriverV1Beta1(ctx context.Context, client storageclientv1beta1.CSIDriversGetter, recorder events.Recorder, required *storagev1beta1.CSIDriver) (*storagev1beta1.CSIDriver, bool, error) {
-	existing, err := client.CSIDrivers().Get(ctx, required.Name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		requiredCopy := required.DeepCopy()
-		actual, err := client.CSIDrivers().Create(
-			ctx, resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*storagev1beta1.CSIDriver), metav1.CreateOptions{})
-		reportCreateEvent(recorder, required, err)
-		return actual, true, err
+// ApplyCSIDriver merges objectmeta, does not worry about anything else
+func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter, recorder events.Recorder, requiredOriginal *storagev1.CSIDriver) (*storagev1.CSIDriver, bool, error) {
+
+	required := requiredOriginal.DeepCopy()
+	if required.Annotations == nil {
+		required.Annotations = map[string]string{}
 	}
+	err := SetSpecHashAnnotation(&required.ObjectMeta, required.Spec)
 	if err != nil {
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
-	existingCopy := existing.DeepCopy()
-
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if !*modified {
-		return existingCopy, false, nil
-	}
-
-	if klog.V(4).Enabled() {
-		klog.Infof("CSIDriver %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
-	}
-
-	actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
-	reportUpdateEvent(recorder, required, err)
-	return actual, true, err
-}
-
-// ApplyCSIDriver merges objectmeta, does not worry about anything else
-func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter, recorder events.Recorder, required *storagev1.CSIDriver) (*storagev1.CSIDriver, bool, error) {
 	existing, err := client.CSIDrivers().Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()
@@ -103,21 +81,46 @@ func ApplyCSIDriver(ctx context.Context, client storageclientv1.CSIDriversGetter
 		return nil, false, err
 	}
 
-	modified := resourcemerge.BoolPtr(false)
+	metadataModified := resourcemerge.BoolPtr(false)
 	existingCopy := existing.DeepCopy()
+	resourcemerge.EnsureObjectMeta(metadataModified, &existingCopy.ObjectMeta, required.ObjectMeta)
 
-	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
-	if !*modified {
-		return existingCopy, false, nil
+	requiredSpecHash := required.Annotations[specHashAnnotation]
+	existingSpecHash := existing.Annotations[specHashAnnotation]
+	sameSpec := requiredSpecHash == existingSpecHash
+	if sameSpec && !*metadataModified {
+		return existing, false, nil
 	}
 
 	if klog.V(4).Enabled() {
 		klog.Infof("CSIDriver %q changes: %v", required.Name, JSONPatchNoError(existing, existingCopy))
 	}
 
-	// TODO: Spec is read-only, so this will fail if user changes it. Should we simply ignore it?
-	actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
-	reportUpdateEvent(recorder, required, err)
+	if sameSpec {
+		// Update metadata by a simple Update call
+		actual, err := client.CSIDrivers().Update(ctx, existingCopy, metav1.UpdateOptions{})
+		reportUpdateEvent(recorder, required, err)
+		return actual, true, err
+	}
+
+	existingCopy.Spec = required.Spec
+	existingCopy.ObjectMeta.ResourceVersion = ""
+	// Spec is read-only after creation. Delete and re-create the object
+	err = client.CSIDrivers().Delete(ctx, existingCopy.Name, metav1.DeleteOptions{})
+	reportDeleteEvent(recorder, existingCopy, err, "Deleting CSIDriver to re-create it with updated parameters")
+	if err != nil && !apierrors.IsNotFound(err) {
+		return existing, false, err
+	}
+	actual, err := client.CSIDrivers().Create(ctx, existingCopy, metav1.CreateOptions{})
+	if err != nil && apierrors.IsAlreadyExists(err) {
+		// Delete() few lines above did not really delete the object,
+		// the API server is probably waiting for a finalizer removal or so.
+		// Report an error, but something else than "Already exists", because
+		// that would be very confusing - Apply failed because the object
+		// already exists???
+		err = fmt.Errorf("failed to re-create CSIDriver object %s, waiting for the original object to be deleted", existingCopy.Name)
+	}
+	reportCreateEvent(recorder, existingCopy, err)
 	return actual, true, err
 }
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -61,7 +61,7 @@ type StaticResourceController struct {
 	name                   string
 	manifests              []conditionalManifests
 	ignoreNotFoundOnCreate bool
-	preconfitions          []StaticResourcesPreconditionsFuncType
+	preconditions          []StaticResourcesPreconditionsFuncType
 
 	operatorClient v1helpers.OperatorClient
 	clients        *resourceapply.ClientHolder
@@ -106,7 +106,7 @@ func NewStaticResourceController(
 		operatorClient: operatorClient,
 		clients:        clients,
 
-		preconfitions: []StaticResourcesPreconditionsFuncType{defaultStaticResourcesPreconditionsFunc},
+		preconditions: []StaticResourcesPreconditionsFuncType{defaultStaticResourcesPreconditionsFunc},
 
 		eventRecorder: eventRecorder.WithComponentSuffix(strings.ToLower(name)),
 
@@ -136,7 +136,7 @@ func (c *StaticResourceController) WithIgnoreNotFoundOnCreate() *StaticResourceC
 //
 // When the requirement is not met, the controller reports degraded status.
 func (c *StaticResourceController) WithPrecondition(precondition StaticResourcesPreconditionsFuncType) *StaticResourceController {
-	c.preconfitions = append(c.preconfitions, precondition)
+	c.preconditions = append(c.preconditions, precondition)
 	return c
 }
 
@@ -283,7 +283,7 @@ func (c *StaticResourceController) Sync(ctx context.Context, syncContext factory
 		return nil
 	}
 
-	for _, precondition := range c.preconfitions {
+	for _, precondition := range c.preconditions {
 		ready, err := precondition(ctx)
 		// We don't care about the other preconditions, we just stop on the first one.
 		if !ready {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -237,7 +237,7 @@ github.com/openshift/client-go/config/informers/externalversions/config
 github.com/openshift/client-go/config/informers/externalversions/config/v1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
-# github.com/openshift/library-go v0.0.0-20220117173518-ca57b619b5d6
+# github.com/openshift/library-go v0.0.0-20220308152156-227dd2b19774
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
And set other CSIDriver fields. Since volumes of this CSI driver always support `fsGroup`, don't depend on Kubernetes heuristics (`ReadWriteOnceWithFSType`) and always apply it.

This updates library-go to https://github.com/openshift/library-go/pull/1324 to re-create driver's CSIDriver instance if the operator needs to change it.

It's somewhat related to https://bugzilla.redhat.com/show_bug.cgi?id=2058626, it makes sure the BZ never happens again.

cc @openshift/storage