### PR TITLE
Remove Ephemeral mode from the CSI driver

### DIFF
--- a/assets/csidriver.yaml
+++ b/assets/csidriver.yaml
@@ -7,4 +7,3 @@ spec:
   podInfoOnMount: true
   volumeLifecycleModes:
   - Persistent
-  - Ephemeral


### PR DESCRIPTION
[In-line ephemeral CSI volumes can be dangerous](https://github.com/kubernetes/cloud-provider-openstack/issues/1493). Users of Cinder should use generic ephemeral volumes, that don't need any special enablement and from the point of a CSI driver, they're just regular PVs/PVCs.

In-line ephemeral CSI volumes are not yet officially supported by OCP, IMO we can remove their support without any deprecation.

cc @openshift/team-openstack 