### PR TITLE
Add OpenStack team to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,5 +4,5 @@ approvers:
 - tsmetana
 - gnufied
 - dobsonj
-- mandre
+- openstack-approvers
 component: "Storage"

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,10 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
+
+aliases:
+  openstack-approvers:
+  - EmilienM
+  - mandre
+  - MaysaMacedo
+  - mdbooth
+  - pierreprinetti
+  - stephenfin


### PR DESCRIPTION
Add the OpenStack folks into the approvers list via our regular team alias.
