### PR TITLE
Bug 2090662: SWEET32: Improve TLS configuration for Kube RBAC Proxy

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -120,6 +120,7 @@ spec:
           - --upstream=http://127.0.0.1:8202/
           - --tls-cert-file=/etc/tls/private/tls.crt
           - --tls-private-key-file=/etc/tls/private/tls.key
+          - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
           - --logtostderr=true
           image: ${KUBE_RBAC_PROXY_IMAGE}
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
CVE-2016-2183
CVE-2016-6329

The default ciphers are not secure and are susceptible to a number of
different known vulnerabilities. This collection of ciphers should be
more secure and have no known vulnerabilities present.

Specific ciphers cribbed from https://github.com/openshift/cluster-machine-approver/commit/1f541e8a321ae57e1a8b1daf8c7890d96ae9e367