### PR TITLE
Bug OCPBUGS-2845: Add SecretHashAnnotation to node service

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -154,6 +154,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		kubeClient,
 		kubeInformersForNamespaces.InformersFor(util.DefaultNamespace),
 		[]factory.Informer{configMapInformer.Informer()},
+		csidrivernodeservicecontroller.WithSecretHashAnnotationHook(util.DefaultNamespace, secretName, secretInformer),
 		csidrivernodeservicecontroller.WithObservedProxyDaemonSetHook(),
 		csidrivernodeservicecontroller.WithCABundleDaemonSetHook(
 			util.DefaultNamespace,


### PR DESCRIPTION
Ensure node service is updated if the credentials secret is changed.