### PR TITLE
WIP: Bump go to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/openstack-cinder-csi-driver-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gophercloud/gophercloud v0.24.0


### PR DESCRIPTION
Just testing go vendoring in go 1.19, not to be merged