### PR TITLE
[release-4.10] Bug OCPBUGS-4717: Add SecretHashAnnotation to node service

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -140,6 +140,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		kubeClient,
 		kubeInformersForNamespaces.InformersFor(defaultNamespace),
 		[]factory.Informer{configMapInformer.Informer()},
+		csidrivernodeservicecontroller.WithSecretHashAnnotationHook(defaultNamespace, secretName, secretInformer),
 		csidrivernodeservicecontroller.WithObservedProxyDaemonSetHook(),
 		csidrivernodeservicecontroller.WithCABundleDaemonSetHook(
 			defaultNamespace,


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/openshift/openstack-cinder-csi-driver-operator/pull/99.
Supersedes https://github.com/openshift/openstack-cinder-csi-driver-operator/pull/102.