### PR TITLE
STOR-1078: Add hostPaths necessary for SELinux mounts

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -67,6 +67,10 @@ spec:
               readOnly: true
             - name: cacert
               mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+            - name: etc-selinux
+              mountPath: /etc/selinux
+            - name: sys-fs
+              mountPath: /sys/fs
           ports:
             - name: healthz
               # Due to hostNetwork, this port is open on all nodes!
@@ -168,3 +172,11 @@ spec:
             - key: ca-bundle.pem
               path: ca-bundle.pem
             optional: true
+        - name: etc-selinux
+          hostPath:
+            path: /etc/selinux
+            type: DirectoryOrCreate
+        - name: sys-fs
+          hostPath:
+            path: /sys/fs
+            type: Directory


### PR DESCRIPTION
To support `mount -o context=XYZ`, /etc/selinux and /sys/fs/selinux from the host must be present in the CSI driver container.

For @openshift/team-openstack folks, this mount option will be used by Kubernetes 1.26 (~4.13) when feature gate [`SELinuxMountReadWriteOncePod` is enabled](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling), i.e. as dev preview. I just want to be able to test it in OCP with all CSI drivers that we ship to make sure it works as we expect.

cc @openshift/storage 