### PR TITLE
OCPBUGS-16783: Chore: Update OWNERS and OWNERS_ALIASES

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,5 @@
 approvers:
-- bertinatto
-- jsafrane
-- tsmetana
-- gnufied
-- dobsonj
+approvers:
+- openshift-storage-maintainers
 - openstack-approvers
-component: "Storage"
+component: "Storage / Operators"

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,3 +8,11 @@ aliases:
   - mdbooth
   - pierreprinetti
   - stephenfin
+  openshift-storage-maintainers:
+  - jsafrane
+  - tsmetana
+  - gnufied
+  - bertinatto
+  - dobsonj
+  - RomanBednar
+  - mpatlasov


### PR DESCRIPTION
Changing the component as per the other Storage repos and adding Roman and Maxim in storage maintainers. And move storage maintainers from OWNERS to OWNERS_ALIASES.