### PR TITLE
STOR-1281: Make Cinder CSI Driver Topology feature configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This allows the operator to automatically configure the Cinder CSI Driver and mi
 ```shell
 apiVersion: v1
 data:
+  enable_topology: "true"
   cloud.conf: |
     [Global]
     ...

--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -96,7 +96,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
-            - "--feature-gates=Topology=true"
+            - "--feature-gates=Topology=$(ENABLE_TOPOLOGY)"
             - "--default-fstype=ext4"
             - "--http-endpoint=localhost:8202"
             - "--leader-election"
@@ -107,6 +107,11 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: ENABLE_TOPOLOGY
+              valueFrom:
+                configMapKeyRef:
+                  name: cloud-conf
+                  key: enable_topology
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/pkg/controllers/config/cloudinfo.go
+++ b/pkg/controllers/config/cloudinfo.go
@@ -52,22 +52,6 @@ func enableTopologyFeature() (bool, error) {
 	return true, nil
 }
 
-func isMultiAZDeployment() (bool, error) {
-	var err error
-
-	if ci == nil {
-		ci, err = getCloudInfo()
-		if err != nil {
-			return false, fmt.Errorf("couldn't collect info about cloud availability zones: %w", err)
-		}
-	}
-
-	// We consider a cloud multiaz when it either have several different zones
-	// or compute and volumes are different.
-	differentZones := len(ci.ComputeZones) > 0 && len(ci.VolumeZones) > 0 && ci.ComputeZones[0] != ci.VolumeZones[0]
-	return len(ci.ComputeZones) > 1 || len(ci.VolumeZones) > 1 || differentZones, nil
-}
-
 // getCloudInfo fetches and caches metadata from openstack
 func getCloudInfo() (*CloudInfo, error) {
 	var ci *CloudInfo

--- a/pkg/controllers/config/configsync_test.go
+++ b/pkg/controllers/config/configsync_test.go
@@ -19,7 +19,6 @@ func TestTranslateConfigMap(t *testing.T) {
 		name                  string
 		source                string
 		target                string
-		isMultiAZDeployment   bool
 		enableTopologyFeature bool
 		errMsg                string
 	}{
@@ -48,10 +47,7 @@ kubeconfig-path = https://foo`,
 			target: `[Global]
 use-clouds  = true
 clouds-file = /etc/kubernetes/secret/clouds.yaml
-cloud       = openstack
-
-[BlockStorage]
-ignore-volume-az = no`,
+cloud       = openstack`,
 		}, {
 			name: "Non-empty config",
 			source: `[BlockStorage]
@@ -60,10 +56,7 @@ trust-device-path = /dev/sdb1
 [Global]
 secret-name = openstack-credentials
 secret-namespace = kube-system`,
-			target: `[BlockStorage]
-ignore-volume-az = no
-
-[Global]
+			target: `[Global]
 use-clouds  = true
 clouds-file = /etc/kubernetes/secret/clouds.yaml
 cloud       = openstack`,
@@ -72,12 +65,8 @@ cloud       = openstack`,
 			source: `
 [BlockStorage]
 trust-device-path = /dev/sdb1`,
-			isMultiAZDeployment:   true,
 			enableTopologyFeature: true,
-			target: `[BlockStorage]
-ignore-volume-az = yes
-
-[Global]
+			target: `[Global]
 use-clouds  = true
 clouds-file = /etc/kubernetes/secret/clouds.yaml
 cloud       = openstack`,
@@ -85,14 +74,9 @@ cloud       = openstack`,
 			name: "User-provided AZ configuration is not overridden",
 			source: `
 [BlockStorage]
-trust-device-path = /dev/sdb1
-ignore-volume-az = yes`,
-			isMultiAZDeployment:   false,
+trust-device-path = /dev/sdb1`,
 			enableTopologyFeature: true,
-			target: `[BlockStorage]
-ignore-volume-az = yes
-
-[Global]
+			target: `[Global]
 use-clouds  = true
 clouds-file = /etc/kubernetes/secret/clouds.yaml
 cloud       = openstack`,
@@ -121,7 +105,7 @@ cloud       = openstack`,
 					"enable_topology": strconv.FormatBool(tc.enableTopologyFeature),
 				},
 			}
-			actualConfigMap, err := translateConfigMap(&sourceConfigMap, tc.isMultiAZDeployment, tc.enableTopologyFeature)
+			actualConfigMap, err := translateConfigMap(&sourceConfigMap, tc.enableTopologyFeature)
 			if tc.errMsg != "" {
 				g.Expect(err).Should(MatchError(tc.errMsg))
 				return


### PR DESCRIPTION
Currently, the topology feature is always enabled, regardless of any cloud-specific configuration. While topology awareness can be a good thing, it doesn't work so well in environments where e.g. there are multiple compute AZs but only a single storage AZ (e.g. non-HCI [1] deployments). We had previously relied on the `ignore_volume_az` flag to workaround this but as we've discovered, this doesn't do what we'd expect it to do [2].

Provide a mechanism for disabling topology functionality automatically based on the compute and storage AZs. In short, if the number and names of AZs are identical between the two services the it is assumed that the environment is a correctly-configured multi-AZ environment and topology-awareness should be *enabled*. If this is not the case, topology-awareness should be *disabled*. This is achieved by adding a new key to the configmap generated by the operator, which is later consumed when deploying our controller.

We also remove setting the old `ignore_volume_az` value since we know it doesn't do anything useful.

[1] https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.2/html-single/hyperconverged_infrastructure_guide/index
[2] https://github.com/kubernetes/cloud-provider-openstack/issues/2185
