### PR TITLE
OCPBUGS-34792: Make Cinder CSI Driver Topology feature configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This allows the operator to automatically configure the Cinder CSI Driver and mi
 ```shell
 apiVersion: v1
 data:
+  enable_topology: "true"
   cloud.conf: |
     [Global]
     ...

--- a/README.md
+++ b/README.md
@@ -2,9 +2,97 @@
 
 An operator to deploy the [OpenStack Cinder CSI driver](https://github.com/openshift/cloud-provider-openstack/tree/master/pkg/csi/cinder) in OpenShift.
 
-# Quick start
+## Configuration
 
-Before running the operator manually, you must remove the operator installed by CSO/CVO
+The operator can be configured using a config map, which by default is found at either `openshift-config / cinder-csi-config` or `openshift-config / cloud-provider-config`.
+The former is preferred as it stores configuration solely for the Cinder CSI Driver.
+It is supported starting in OpenShift 4.14 and should be used in all new deployments.
+As the name might suggest, the latter stores configuration for both the Cinder CSI driver and the OpenStack Cloud Provider.
+It is used for legacy reasons.
+
+Configuration must be stored in the config map under the `config` key. For example, if using the `openshift-config / cinder-csi-config` config map:
+
+```shell
+oc get configmap -n openshift-config cinder-csi-config -o yaml
+```
+
+```yaml
+apiVersion: v1
+data:
+  ca-bundle.pem: |
+    <redacted>
+  config: |
+    [Global]
+    ...
+    [BlockStorage]
+    ...
+kind: ConfigMap
+metadata:
+  name: cinder-csi-config
+  namepsace: openshift-config
+```
+
+Alternatively, if using the `openshift-config / cloud-provider-config` config map:
+
+```shell
+oc get configmap -n openshift-config cloud-provider-config -o yaml
+```
+
+```yaml
+apiVersion: v1
+data:
+  config: |
+    [Global]
+    ...
+    [BlockStorage]
+    ...
+kind: ConfigMap
+metadata:
+  name: cloud-provider-config
+  namepsace: openshift-config
+```
+
+> *Note*
+> The `openshift-config / cloud-provider-config` config map stores configuration for both services for historical reasons: previously, block device management was handled by the cloud provider.
+> This was decoupled in the 4.14 release, but support for loading configuration from the `openshift-config / cloud-provider-config` config map is retained to avoid breaking exist deployments.
+> Only values from the `[Global]`, `[BlockStorage]` and `[Metadata]` sections are relevant. The remainder are ignored by the CSI driver.
+> A full list of supported configuration options can be found in the [OpenStack Cloud Provider documentation](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/using-cinder-csi-plugin.md#driver-config).
+
+> *Note*
+> The name of the config map, `cloud-provider-config`, is configurable and is derived from the `infrastructure / cluster` CRD.
+>
+>     oc get infrastructure cluster -o=jsonpath="{.spec.cloudConfig.name}"
+>     cloud-provider-config
+>
+> If this has been modified, then the Cinder CSI Driver Operator, Cluster Cloud Controller Manager Operator,
+> and other operators and services that depend on this config map will the modified name.
+> This does not apply if the newer `cindre-csi-config` config map.
+> For more information, refer to the [OpenShift documentation](https://docs.openshift.com/container-platform/4.12/rest_api/config_apis/infrastructure-config-openshift-io-v1.html#spec-cloudconfig).
+
+The operator loads this configuration, performs some minimal modification and validation, and saves the modified configurations to a new config map, stored at `openshift-cluster-csi-drivers / cloud-conf` under the `cloud.conf` key.
+This generated config map is what is ultimately used by the Cinder CSI Driver.
+This allows the operator to automatically configure the Cinder CSI Driver and minimise the possibility of accidental misconfiguration.
+
+```shell
+apiVersion: v1
+data:
+  cloud.conf: |
+    [Global]
+    ...
+    [BlockStorage]
+    ...
+kind: ConfigMap
+metadata:
+  name: cloud-conf
+  namespace: openshift-cluster-csi-drivers
+```
+
+Modifications to the generated `openshift-cluster-csi-drivers / cloud-conf` config map will be ignored and will be overridden by the operator.
+Any changes made should be made to the `openshift-config / cinder-csi-config` or `openshift-config / cloud-provider-config` config maps.
+
+## Development
+
+Before running the operator manually, you must remove the operator installed by CVO and CSO:
 
 ```shell
 # Scale down CVO and CSO
@@ -15,7 +103,7 @@ oc scale --replicas=0 deploy/cluster-storage-operator -n openshift-cluster-stora
 oc -n openshift-cluster-csi-drivers delete deployment.apps/openstack-cinder-csi-driver-operator deployment.apps/openstack-cinder-csi-driver-controller daemonset.apps/openstack-cinder-csi-driver-node
 ```
 
-To build and run the operator locally:
+You can then build and run the operator locally:
 
 ```shell
 # Create only the resources the operator needs to run via CLI

--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -96,7 +96,7 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
-            - "--feature-gates=Topology=true"
+            - "--feature-gates=Topology=$(ENABLE_TOPOLOGY)"
             - "--default-fstype=ext4"
             - "--http-endpoint=localhost:8202"
             - "--leader-election"
@@ -107,6 +107,11 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: ENABLE_TOPOLOGY
+              valueFrom:
+                configMapKeyRef:
+                  name: cloud-conf
+                  key: enable_topology
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/pkg/controllers/config/cloudinfo.go
+++ b/pkg/controllers/config/cloudinfo.go
@@ -36,13 +36,8 @@ func enableTopologyFeature() (bool, error) {
 		}
 	}
 
-	// for us to enable the topology feature, we need to have an equal number
-	// of availability zones for the compute and volume services...
-	if len(ci.ComputeZones) != len(ci.VolumeZones) {
-		return false, nil
-	}
-
-	// and these AZs have to have identical names
+	// for us to enable the topology feature, we need to ensure that for
+	// every compute zone there is a matching volume zone
 	for i := range ci.ComputeZones {
 		if ci.ComputeZones[i] != ci.VolumeZones[i] {
 			return false, nil

--- a/pkg/controllers/config/cloudinfo.go
+++ b/pkg/controllers/config/cloudinfo.go
@@ -52,22 +52,6 @@ func enableTopologyFeature() (bool, error) {
 	return true, nil
 }
 
-func isMultiAZDeployment() (bool, error) {
-	var err error
-
-	if ci == nil {
-		ci, err = getCloudInfo()
-		if err != nil {
-			return false, fmt.Errorf("couldn't collect info about cloud availability zones: %w", err)
-		}
-	}
-
-	// We consider a cloud multiaz when it either have several different zones
-	// or compute and volumes are different.
-	differentZones := len(ci.ComputeZones) > 0 && len(ci.VolumeZones) > 0 && ci.ComputeZones[0] != ci.VolumeZones[0]
-	return len(ci.ComputeZones) > 1 || len(ci.VolumeZones) > 1 || differentZones, nil
-}
-
 // getCloudInfo fetches and caches metadata from openstack
 func getCloudInfo() (*CloudInfo, error) {
 	var ci *CloudInfo

--- a/pkg/controllers/config/configsync_test.go
+++ b/pkg/controllers/config/configsync_test.go
@@ -19,7 +19,6 @@ func TestTranslateConfigMap(t *testing.T) {
 		name                  string
 		source                string
 		target                string
-		isMultiAZDeployment   bool
 		enableTopologyFeature bool
 		errMsg                string
 	}{
@@ -48,10 +47,7 @@ kubeconfig-path = https://foo`,
 			target: `[Global]
 use-clouds  = true
 clouds-file = /etc/kubernetes/secret/clouds.yaml
-cloud       = openstack
-
-[BlockStorage]
-ignore-volume-az = no`,
+cloud       = openstack`,
 		}, {
 			name: "Non-empty config",
 			source: `[BlockStorage]
@@ -60,10 +56,7 @@ trust-device-path = /dev/sdb1
 [Global]
 secret-name = openstack-credentials
 secret-namespace = kube-system`,
-			target: `[BlockStorage]
-ignore-volume-az = no
-
-[Global]
+			target: `[Global]
 use-clouds  = true
 clouds-file = /etc/kubernetes/secret/clouds.yaml
 cloud       = openstack`,
@@ -72,12 +65,8 @@ cloud       = openstack`,
 			source: `
 [BlockStorage]
 trust-device-path = /dev/sdb1`,
-			isMultiAZDeployment:   true,
 			enableTopologyFeature: true,
-			target: `[BlockStorage]
-ignore-volume-az = yes
-
-[Global]
+			target: `[Global]
 use-clouds  = true
 clouds-file = /etc/kubernetes/secret/clouds.yaml
 cloud       = openstack`,
@@ -85,14 +74,9 @@ cloud       = openstack`,
 			name: "User-provided AZ configuration is not overridden",
 			source: `
 [BlockStorage]
-trust-device-path = /dev/sdb1
-ignore-volume-az = yes`,
-			isMultiAZDeployment:   false,
+trust-device-path = /dev/sdb1`,
 			enableTopologyFeature: true,
-			target: `[BlockStorage]
-ignore-volume-az = yes
-
-[Global]
+			target: `[Global]
 use-clouds  = true
 clouds-file = /etc/kubernetes/secret/clouds.yaml
 cloud       = openstack`,
@@ -121,7 +105,7 @@ cloud       = openstack`,
 					"enable_topology": strconv.FormatBool(tc.enableTopologyFeature),
 				},
 			}
-			actualConfigMap, err := translateConfigMap(&sourceConfigMap, tc.isMultiAZDeployment, tc.enableTopologyFeature)
+			actualConfigMap, err := translateConfigMap(&sourceConfigMap, tc.enableTopologyFeature)
 			if tc.errMsg != "" {
 				g.Expect(err).Should(MatchError(tc.errMsg))
 				return


### PR DESCRIPTION
This is manual backport of #127.

We include the contents of #110 to avoid merge conflicts. A backport of that PR is also proposed separately at #157 in case it is helpful to merge separately. The single commit here should disappear when that happens.

We also include the contents of #164 to fix a minor issue in the original version of this feature. This could be done later in a separate PR but it seems more sensible to include this now.