### PR TITLE
OCPBUGS-29986: Fix error when there are no Cinder AZs

### DIFF
--- a/pkg/controllers/config/cloudinfo.go
+++ b/pkg/controllers/config/cloudinfo.go
@@ -130,10 +130,6 @@ func (ci *CloudInfo) getVolumeZones() ([]string, error) {
 		return nil, fmt.Errorf("failed to parse response with volume availability zone list: %w", err)
 	}
 
-	if len(availabilityZoneInfo) == 0 {
-		return nil, fmt.Errorf("could not find an available volume availability zone")
-	}
-
 	var zones []string
 	for _, zone := range availabilityZoneInfo {
 		if zone.ZoneState.Available {


### PR DESCRIPTION
If Cinder is configured without AZs we were generating an error in config sync rather than just disabling the topology feature.