### PR TITLE
OCPBUGS-30951: Relax requirement to enable topology

### DIFF
--- a/pkg/controllers/config/cloudinfo.go
+++ b/pkg/controllers/config/cloudinfo.go
@@ -36,13 +36,8 @@ func enableTopologyFeature() (bool, error) {
 		}
 	}
 
-	// for us to enable the topology feature, we need to have an equal number
-	// of availability zones for the compute and volume services...
-	if len(ci.ComputeZones) != len(ci.VolumeZones) {
-		return false, nil
-	}
-
-	// and these AZs have to have identical names
+	// for us to enable the topology feature, we need to ensure that for
+	// every compute zone there is a matching volume zone
 	for i := range ci.ComputeZones {
 		if ci.ComputeZones[i] != ci.VolumeZones[i] {
 			return false, nil


### PR DESCRIPTION
The only requirement is that for every compute zone we have a matching volume zone with the same name. It's perfectly fine to have extra volume zones, as the scheduler won't provision volumes on them.

It is still possible for users to overwrite that default and set the `enable_topology` key to the desired value in the
`openshift-config/cloud-provider-config` config map.