### PR TITLE
OCPBUGS-34870: Correct out-of-bounds check

### DIFF
--- a/pkg/controllers/config/cloudinfo.go
+++ b/pkg/controllers/config/cloudinfo.go
@@ -36,10 +36,24 @@ func enableTopologyFeature() (bool, error) {
 		}
 	}
 
-	// for us to enable the topology feature, we need to ensure that for
-	// every compute zone there is a matching volume zone
-	for i := range ci.ComputeZones {
-		if ci.ComputeZones[i] != ci.VolumeZones[i] {
+	// for us to enable the topology feature we should have a corresponding
+	// compute AZ for each volume AZ: if we have more compute AZs than volume
+	// AZs then this clearly isn't the case
+	if len(ci.ComputeZones) > len(ci.VolumeZones) {
+		return false, nil
+	}
+
+	// likewise if the names of the various AZs don't match, that clearly isn't
+	// true
+	for _, computeZone := range ci.ComputeZones {
+		var found bool
+		for _, volumeZone := range ci.VolumeZones {
+			if computeZone == volumeZone {
+				found = true
+				break
+			}
+		}
+		if !found {
 			return false, nil
 		}
 	}


### PR DESCRIPTION
Ensure that we have the same number or fewer compute AZs than volume AZs. Also better handle mismatches between the two.

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
Suggested-by: Daniel Kobras (@dkobras)
