### PR TITLE
OSASINFRA-3609: Mark the repository as obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!warning]
+> **This repo is obsolete in OCP 4.18.**
+> OpenStack Cinder CSI driver operator in 4.18 and newer is built from https://github.com/openshift/csi-operator.
+> 4.17 and older branches in this repo are still in use, until EOL of the corresponding OCP version.
+> See [this enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/storage/csi-driver-operator-merge.md) for details.
+
 # Cinder CSI driver operator
 
 An operator to deploy the [OpenStack Cinder CSI driver](https://github.com/openshift/cloud-provider-openstack/tree/master/pkg/csi/cinder) in OpenShift.


### PR DESCRIPTION
We are in the process of migrating everything across to csi-operator. See [[1]] and [[2]] for more context.

[1]: https://github.com/openshift/csi-operator/pull/278
[2]: https://github.com/openshift/release/pull/56812
